### PR TITLE
Enabling UPX for GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,9 @@ builds:
       - -w
 
 upx:
-  enabled: true
-  compress: best
-  lzma: true
+  - enabled: true
+    compress: best
+    lzma: true
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
This adds configuration option for enabling UPX packing for binaries released with GoReleaser.