### PR TITLE
Add OTLP HTTP exporter to the agent

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -51,6 +51,8 @@ processors:
 exporters:
   # OTel Collector OTLP GRPC exporter.
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v$BUILDER_VERSION
+  # OTel Collector OTLP HTTP exporter.
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v$BUILDER_VERSION
 EOF
 
 echo "Building AccurateScaler OTel Collector Agent"


### PR DESCRIPTION
Here we're adding the OTLP HTTP exporter to the agent to have the possibility to switch between HTTP/GRPC exporters in case it's needed.